### PR TITLE
Small fix on miniwindows setup

### DIFF
--- a/modules/corelib/ui/uiminiwindow.lua
+++ b/modules/corelib/ui/uiminiwindow.lua
@@ -156,6 +156,7 @@ function UIMiniWindow:setup()
         local parent = rootWidget:recursiveGetChildById(selfSettings.parentId)
         if parent then
           if parent:getClassName() == 'UIMiniWindowContainer' and selfSettings.index and parent:isOn() then
+            self:setParent(parent, true)
             self.miniIndex = selfSettings.index
             parent:scheduleInsert(self, selfSettings.index)
           elseif selfSettings.position then


### PR DESCRIPTION
Small fix on miniwindows setup (the last miniwindow moved from one parent to another, when parent was a MiniWindowContainer, would not setup properly, being sent to it's old parent on client restart)