### PR TITLE
(fix) clean callbacks on terminate to avoid callbacks duplication

### DIFF
--- a/modules/game_bot/functions/server.lua
+++ b/modules/game_bot/functions/server.lua
@@ -70,6 +70,7 @@ context.BotServer.terminate = function()
   if context.BotServer._websocket then
     context.BotServer._websocket:close()
     context.BotServer._websocket = nil
+    context.BotServer._callbacks = {}
   end
 end
 


### PR DESCRIPTION
Turn the server on/off many times without reset the bot cause to duplicate the listeners callbacks.