### PR TITLE
eatfood delay added

### DIFF
--- a/modules/game_bot/default_configs/vBot_4.8/vBot/eat_food.lua
+++ b/modules/game_bot/default_configs/vBot_4.8/vBot/eat_food.lua
@@ -39,6 +39,7 @@ macro(500, "Eat Food", function()
     for __, item in ipairs(container:getItems()) do
       for i, foodItem in ipairs(storage.foodItems) do
         if item:getId() == foodItem.id then
+          delay(30000)  -- Adiciona um delay de 30 segundos
           return g_game.use(item)
         end
       end


### PR DESCRIPTION
Explicação:
delay(30000): Esta função pausa a execução do script por 30 segundos (30000 milissegundos) antes de continuar. Isso significa que, após encontrar um item de comida e antes de usá-lo, o script irá esperar 30 segundos.

Observação:
Certifique-se de que o delay seja colocado no local correto do script para que ele não afete outras operações que não devem ser atrasadas.

Se você quiser que o delay seja aplicado apenas em situações específicas, você pode adicionar condições adicionais ao redor da função delay().

Esse ajuste deve resolver o problema do script estar comendo sem parar, adicionando um intervalo de 30 segundos entre cada uso de comida.